### PR TITLE
Fix/zero distance issue

### DIFF
--- a/examples/index2-test-duplicate-data.html
+++ b/examples/index2-test-duplicate-data.html
@@ -15,12 +15,12 @@
 
 <body>
 <h1 style="text-align: center; width: 100%">MeCu-Graph</h1>
-<div id="container" style="display:flex">
+<div id="container" style="display:flex; justify-content: column;">
     <div id="mecuGraph1"></div>
 </div>
 
-<script src="../build/mecu-graph.js"></script>
 <script src="../lib/disi.js"></script>
+<script src="../build/mecu-graph.js"></script>
 
 <script>
     let readData = [
@@ -71,11 +71,11 @@
             "experiments": [
                 {
                     "experiment": 1,
-                    "reads": readData
+                    "reads": readData.map(d => ({t:d.t, r:d.r*1.1}))
                 },
                 {
                     "experiment": 2,
-                    "reads": readData
+                    "reads": readData.map(d => ({t:d.t, r:d.r*2}))
                 }
             ]
         },
@@ -107,38 +107,9 @@
         },
     ];
 
-    var graph0 = new MecuGraph({element: "#mecuGraph1"});
-    graph0.add(data);
+    const graph1 = new MecuGraph({element: '#mecuGraph1'});
+    graph1.add(data)
 
-    const changeDistanceMetricOfGraph = (graph) => {
-        setTimeout(() => {
-                changeMetricRandomly(graph);
-                changeDistanceMetricOfGraph(graph);
-            },
-            2000
-        );
-    }
-
-    const changeMetricRandomly = (graph) => {
-        const r = Math.floor(Math.random() * 4) + 1;
-        console.log(`r`, r);
-        switch (r) {
-            case 1:
-                graph.changeDistanceMetric(Disi.supremum);
-                break;
-            case 2:
-                graph.changeDistanceMetric(Disi.euclidian);
-                break;
-            case 3:
-                graph.changeDistanceMetric(Disi.manhattan);
-                break;
-            case 4:
-                graph.changeDistanceMetric((a,b) => Disi.minkowski(a,b, Math.floor(Math.random() * 3)+1) );
-                break;
-        }
-    }
-
-    changeDistanceMetricOfGraph(graph0);
 
 </script>
 </body>

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,7 @@
 
 const cytoscape = require('cytoscape');
 const cycola = require('cytoscape-cola');
-cycola(cytoscape); // register extension
+cytoscape.use(cycola); // register extension
 const everpolate = require('everpolate');
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,8 @@ const cycola = require('cytoscape-cola');
 cytoscape.use(cycola); // register extension
 const everpolate = require('everpolate');
 
+const FRACTION_OF_MIN_TO_USE_AS_ZERO_VALUE_INSTEAD = 0.1;
+
 /**
  * Go from the API response format to a Protein+Experiment+TempReads format
  *  -- Optionally get the UNSORTED!! range of temperatures
@@ -164,6 +166,27 @@ let getGraphDataFromExtractedProteins = function(proteins, distance = euclidian)
 };
 
 /**
+ * extracts the min non zero weight out of an array of edges
+ * @param  {edges[]} arr    array of edges, computed from getGraphDataFromExtractedProteins
+ * @return {Number}         minimum non zero value of an array of weights
+ */
+const getMinNonZeroWeight = (arr) => {
+    let min = Number.MAX_VALUE;
+    arr.forEach(e => e.data.weight < min && e.data.weight > 0 ? min = e.data.weight : '');
+    return min*FRACTION_OF_MIN_TO_USE_AS_ZERO_VALUE_INSTEAD;
+}
+
+/**
+ * replaces all the zero value weights of an edges array with a value
+ * modifies the input array
+ * @param  {edges[]} arr            edges array, computed from getGraphDataFromExtractedProteins
+ * @param  {Number} nonZeroValue    value to replace all zeros with
+ */
+const replaceZeroWithValue = (arr, nonZeroValue) => {
+    arr.forEach(e => e.data.weight === 0 ? e.data.weight = nonZeroValue : '')
+}
+
+/**
  * Extend string prototypes to allow color hashing
  */
 String.prototype.getHashCode = function() {
@@ -235,15 +258,17 @@ class MecuGraph {
                     'opacity': '1',
 
                     'text-opacity': '1'
-                })
-            ,
+                }),
             layout: {
                 name: 'cola',
                 fit: false,
                 infinite: true,
-                edgeLength: function(e){ return (e.data('weight') || 0.001)*self.options.edgeLength; }
+                edgeLength: function(e){
+                    return (e.data('weight') || 0.001)*self.options.edgeLength;
+                }
             }
         });
+
     }
 
     /**
@@ -276,12 +301,8 @@ class MecuGraph {
         // Use all the data because you need all the edges!
         let [nodes, edges] = getGraphDataFromExtractedProteins(this.data, this.options.distanceMetric);
 
-        preventDivisionThroughZero(edges);
-
-        // set edges with weith 0 to nearly 0
-        edges.forEach(edge => {
-            if(edge.data.weight === 0) edge.data.weight = 0.000000001;
-        });
+        const minNonZeroWeightFraction = getMinNonZeroWeight(edges);
+        replaceZeroWithValue(edges, minNonZeroWeightFraction);
 
         this.nodes = nodes;
         this.edges = edges;
@@ -324,7 +345,8 @@ class MecuGraph {
 
         let [nodes, edges] = getGraphDataFromExtractedProteins(this.data, this.options.distanceMetric);
 
-        preventDivisionThroughZero(edges);
+        const minNonZeroWeightFraction = getMinNonZeroWeight(edges);
+        replaceZeroWithValue(edges, minNonZeroWeightFraction);
 
         this.nodes = nodes;
         this.edges = edges;
@@ -345,7 +367,8 @@ class MecuGraph {
 
         let [nodes, edges] = getGraphDataFromExtractedProteins(this.data, this.options.distanceMetric);
 
-        preventDivisionThroughZero(edges);
+        const minNonZeroWeightFraction = getMinNonZeroWeight(edges);
+        replaceZeroWithValue(edges, minNonZeroWeightFraction);
 
         this.nodes = nodes;
         this.edges = edges;
@@ -366,21 +389,17 @@ class MecuGraph {
     setEdgeLength(length){
         this.options.edgeLength = length || this.options.edgeLength;
         let self = this;
-        this.graph.layout({
+        let l = this.graph.layout({
             name: 'cola',
             fit: false,
-            infinite: true,
-            edgeLength: function(e){ return e.data('weight')*self.options.edgeLength; }
+            infinite:true,
+            edgeLength: function(e){
+                return (e.data('weight') || 0.001)*self.options.edgeLength;
+            }
         });
+
+        l.run();
     }
-}
-
-const preventDivisionThroughZero = (edges) => {
-
-    // set edges with weith 0 to nearly 0
-    edges.forEach(edge => {
-        if(edge.data.weight === 0) edge.data.weight = 0.000000001;
-    });
 
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1046,16 +1046,20 @@
       "dev": true
     },
     "cytoscape": {
-      "version": "2.7.29",
-      "resolved": "http://registry.npmjs.org/cytoscape/-/cytoscape-2.7.29.tgz",
-      "integrity": "sha512-Od1Q6813qAM1nReYtc8Jjsbu/TN2fMkSgVCyMT1ABdiQroxtj9sVS2XUUsnWzjHY8zwTAFtuVg89XBg/E+2qEA=="
+      "version": "3.2.20",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.2.20.tgz",
+      "integrity": "sha512-EtbydFDTa7TTWPulEdefCnI8IvlmyEzP21kCguH194GSdWA5HrWQPjiX66aJoOl6xqU2QCbVks2J7ydKJEbYRg==",
+      "requires": {
+        "heap": "^0.2.6",
+        "lodash.debounce": "^4.0.8"
+      }
     },
     "cytoscape-cola": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/cytoscape-cola/-/cytoscape-cola-1.6.0.tgz",
-      "integrity": "sha1-jpm+icqtjS8Ewa3LORarwf91ZLI=",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/cytoscape-cola/-/cytoscape-cola-2.2.4.tgz",
+      "integrity": "sha512-y2rr3CO4NHyTxEr6+w9jEnOcYj7jcUyg1IG+qsk5FDUAoQmrMHNlQYBHklB+qOcRuNPHvj+TlNlRfP7XXdiNLw==",
       "requires": {
-        "webcola": "^3.1.2"
+        "webcola": "^3.3.6"
       }
     },
     "d3-dispatch": {
@@ -1561,14 +1565,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1583,20 +1585,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1713,8 +1712,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1726,7 +1724,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1741,7 +1738,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1749,14 +1745,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1775,7 +1769,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1856,8 +1849,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1869,7 +1861,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1991,7 +1982,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2232,6 +2222,11 @@
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
       }
+    },
+    "heap": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
+      "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw="
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -2670,8 +2665,7 @@
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-      "dev": true
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
     "lodash.memoize": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "prepublish": "webpack"
   },
   "dependencies": {
-    "cytoscape": "^2.7.13",
-    "cytoscape-cola": "^1.4.3",
+    "cytoscape": "^3.2.20",
+    "cytoscape-cola": "^2.2.4",
     "everpolate": "^0.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
upgraded versions of cytoscape and cytoscape-cola

0 distance issue: if there is a distance of 0 length, find the smallest non 0 distance, divide it by 10, and use that instead of the 0 distance
this allows to visualize a cohesion if there is a pair or group of nodes with distance 0 AND still keep the distance relatively correct for the other nodes

without this fix, if there is a distance of length 0 between 2 or more nodes, the rest of the graph has no cohesion, since no other distance is relevant when there is one distance of length 0